### PR TITLE
♻️ (page.tsx, faq.action.ts, home.action.ts): обновление времени кэши…

### DIFF
--- a/src/app/(frontend)/(public)/page.tsx
+++ b/src/app/(frontend)/(public)/page.tsx
@@ -1,6 +1,6 @@
 import { Home } from '@/views/home'
 
-export const revalidate = 180
+export const revalidate = 0
 
 export default async function HomePage() {
   return <Home />

--- a/src/shared/actions/faq.action.ts
+++ b/src/shared/actions/faq.action.ts
@@ -9,7 +9,7 @@ async function fetchFAQ() {
   return gql.GetFAGs()
 }
 export const getFAQ = withRedisCache(fetchFAQ, {
-  ttl: 360,
+  ttl: 180,
   tags: () => [CacheKeys.tags.getFAQ()],
   name: 'fetchFAQ',
 })

--- a/src/shared/actions/home.action.ts
+++ b/src/shared/actions/home.action.ts
@@ -9,7 +9,7 @@ async function fetchHomePage() {
   return gql.GetHomePage()
 }
 export const getHomePage = withRedisCache(fetchHomePage, {
-  ttl: 360,
+  ttl: 180,
   tags: () => [CacheKeys.tags.getHomePage()],
   name: 'fetchHomePage',
 })


### PR DESCRIPTION
…рования и переопределение revalidate

Изменено значение revalidate на 0 в page.tsx для отключения кэширования страницы. Время жизни кэша (ttl) для getFAQ и getHomePage уменьшено с 360 до 180 секунд, чтобы обеспечить более актуальные данные и улучшить пользовательский опыт, особенно для часто обновляемого контента.