### PR TITLE
♻️ (test-card.tsx, useShuffledOnClient.ts): рефакторинг логики переме…

### DIFF
--- a/src/entities/test/ui/test-card.tsx
+++ b/src/entities/test/ui/test-card.tsx
@@ -30,15 +30,17 @@ const TestCard = memo(
 
     const questionName = questionNameFn(question.id)
 
-    const shuffledRight = useShuffledOnClient(question.matchingPairs?.map((p) => p))
+    const shuffledRight = useShuffledOnClient(question.matchingPairs ?? [], question.id)
 
-    const combinedPairs = useMemo(() => {
-      return question.matchingPairs.map((pair, idx) => ({
-        id: pair.id,
-        left: pair.left,
-        right: shuffledRight[idx]?.right ?? '',
-      }))
-    }, [question.matchingPairs, shuffledRight])
+    const combinedPairs = useMemo(
+      () =>
+        question.matchingPairs.map((pair, idx) => ({
+          id: pair.id,
+          left: pair.left,
+          right: shuffledRight[idx]?.right ?? '',
+        })),
+      [question.matchingPairs, shuffledRight],
+    )
 
     const renderContent = useMemo(() => {
       switch (question.questionType) {

--- a/src/shared/hooks/useShuffledOnClient.ts
+++ b/src/shared/hooks/useShuffledOnClient.ts
@@ -1,23 +1,19 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 
-export function useShuffledOnClient<T>(input: readonly T[]): T[] {
+export function useShuffledOnClient<T>(input: readonly T[], depKey: string | number): T[] {
   const [shuffled, setShuffled] = useState<T[]>([])
-  const initialized = useRef(false)
 
   useEffect(() => {
-    if (initialized.current) return
+    if (!input) return
 
-    // снимаем readonly со всего массива
     const copy: T[] = input.map((item) => ({ ...item }))
-
     for (let i = copy.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1))
       ;[copy[i], copy[j]] = [copy[j], copy[i]]
     }
 
     setShuffled(copy)
-    initialized.current = true
-  }, [input])
+  }, [depKey, input.length]) // зависим только от ключа вопроса и длины массива
 
-  return shuffled.length > 0 ? shuffled : input?.slice()
+  return shuffled.length > 0 ? shuffled : [...input]
 }


### PR DESCRIPTION
…шивания пар и улучшение использования хука

💡 (test-card.tsx): добавлен параметр depKey в useShuffledOnClient для отслеживания изменений Изменения в логике перемешивания пар в компоненте TestCard позволяют более эффективно использовать хук useShuffledOnClient. Теперь хук принимает дополнительный параметр depKey, что позволяет отслеживать изменения в зависимости от ключа вопроса и длины массива. Это улучшает производительность и предотвращает ненужные вызовы эффекта.