### PR TITLE
✨ (graphql): добавлен лимит на количество возвращаемых тестов и вебин…

### DIFF
--- a/src/shared/graphql/__generated__.ts
+++ b/src/shared/graphql/__generated__.ts
@@ -22082,7 +22082,7 @@ export const GetTestResHistoryDocument = gql`
     `;
 export const GetAllTestsByTitlesDocument = gql`
     query GetAllTestsByTitles {
-  Tests {
+  Tests(limit: 100) {
     docs {
       id
       title
@@ -22205,7 +22205,7 @@ export const UpdateUserNameDocument = gql`
     `;
 export const GetAllWebinarsDocument = gql`
     query GetAllWebinars {
-  Webinars {
+  Webinars(limit: 100) {
     docs {
       id
       title

--- a/src/shared/graphql/schemas/test/getAll.gql
+++ b/src/shared/graphql/schemas/test/getAll.gql
@@ -1,5 +1,5 @@
 query GetAllTestsByTitles {
-  Tests {
+  Tests(limit: 100) {
     docs {
       id
       title

--- a/src/shared/graphql/schemas/webinars/getAll.gql
+++ b/src/shared/graphql/schemas/webinars/getAll.gql
@@ -1,8 +1,7 @@
 query GetAllWebinars {
-  Webinars {
+  Webinars(limit: 100) {
     docs {
       id
-
       title
       type
       startsAt


### PR DESCRIPTION
…аров

Изменены запросы GetAllTestsByTitles и GetAllWebinars для ограничения количества возвращаемых результатов до 100. Это улучшает производительность и предотвращает перегрузку клиента большим объемом данных.