### PR TITLE
📝 (page.tsx): исправлена опечатка в заголовке метаданных страницы веб…

### DIFF
--- a/src/app/(frontend)/(public)/webinars/page.tsx
+++ b/src/app/(frontend)/(public)/webinars/page.tsx
@@ -18,7 +18,7 @@ async function Page() {
 export default Page
 
 export const metadata: Metadata = {
-  title: 'Рассписание вебинаров | BELKINA.ONLINE',
+  title: 'Расписание вебинаров | BELKINA.ONLINE',
   description:
     'Расписание бесплатных вебинаров по подготовке к ЕГЭ по русскому языку на платформе BELKINA.ONLINE',
 }


### PR DESCRIPTION
…инаров

Исправлена опечатка в заголовке метаданных с "Рассписание" на "Расписание" для улучшения точности и профессионализма контента на странице вебинаров.